### PR TITLE
Add filters before and after scss compilation

### DIFF
--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -301,7 +301,10 @@ if ( ! class_exists( 'WP_Dark_Mode_Hooks' ) ) {
 				$base_selector = apply_filters('wp_dark_mode/base_selectors', 'html.wp-dark-mode-active');
 			}
 
-			ob_start();
+			$css = apply_filters('wp_dark_mode/css', '' );
+
+			if(!$css){
+				ob_start();
 
 			/** declare css variables */
 			printf( '
@@ -387,7 +390,14 @@ if ( ! class_exists( 'WP_Dark_Mode_Hooks' ) ) {
 				}', $base_selector );
 			}
 
-			$scss = ob_get_clean();
+				$scss = ob_get_clean();
+				if ( ! empty( $scss ) ) {
+				    $scss_compiler = new scssc();
+
+					$css = $scss_compiler->compile( $scss );
+					do_action('wp_dark_mode/after_css_compile', $css );
+				}
+			}
 
 			?>
 
@@ -507,10 +517,8 @@ if ( ! class_exists( 'WP_Dark_Mode_Hooks' ) ) {
 
             <style>
                 <?php
-				if ( ! empty( $scss ) ) {
-				    $scss_compiler = new scssc();
-
-					echo $scss_compiler->compile( $scss );
+				if ( ! empty( $css ) ) {
+					echo $css;
 				}
 				?>
             </style>


### PR DESCRIPTION
This filters allows leverage object-caching and to not compile scss on every request:

```
add_filter('wp_dark_mode/css',function($css){
	$key = 'wp_dark_mode_css'. ( is_admin() ? '_admin' : '');
	$transient = get_transient( $key );
	
	if($transient){
		$css = $transient;
	}
	
	return $css;
});

add_action('wp_dark_mode/after_css_compile',function($css){
	$key = 'wp_dark_mode_css'. ( is_admin() ? '_admin' : '');
	set_transient($key, $css, DAY_IN_SECONDS );
});
```